### PR TITLE
Use ammo.js instead of oimo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
             "type": "chrome",
             "url": "https://localhost:8080",
             "webRoot": "${workspaceFolder}/dist",
-            // "sourceMapPathOverrides": {
-            //     "webpack:///../*": "${workspaceFolder}/*",
-            // },
+            "sourceMapPathOverrides": {
+                "webpack://*": "${workspaceFolder}/*",
+            },
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "webpack-dev-server": "^4.10.1"
     },
     "dependencies": {
-        "babylonjs": "^5.22.0",
-        "oimo": "^1.0.9"
+        "ammo.js": "^0.0.10",
+        "babylonjs": "^5.22.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "webpack-dev-server": "^4.10.1"
     },
     "dependencies": {
-        "ammo.js": "^0.0.10",
+        "ammo.js": "github:kripken/ammo.js",
         "babylonjs": "^5.22.0"
     }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,10 +1,13 @@
+import Ammo from 'ammo.js'
 import * as BABYLON from 'babylonjs'
-import * as OIMO from 'oimo'
 
 const createScene = require('./playground.js')
 
 global.canvas = document.getElementsByTagName('canvas')[0]
 global.engine = new BABYLON.Engine(canvas, true)
+
+const ammo = Ammo()
+global.ammo = ammo
 
 const scene = createScene()
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-import Ammo from 'ammo.js'
+import * as Ammo from 'ammo.js'
 import * as BABYLON from 'babylonjs'
 
 const createScene = require('./playground.js')
@@ -6,15 +6,16 @@ const createScene = require('./playground.js')
 global.canvas = document.getElementsByTagName('canvas')[0]
 global.engine = new BABYLON.Engine(canvas, true)
 
-const ammo = Ammo()
-global.ammo = ammo
+new Ammo().then((ammo) => {
+    global.ammo = ammo
 
-const scene = createScene()
+    const scene = createScene()
 
-engine.runRenderLoop(() => {
-    scene.render();
+    engine.runRenderLoop(() => {
+        scene.render();
+    })
+
+    onresize = () => {
+        engine.resize()
+    }
 })
-
-onresize = () => {
-    engine.resize()
-}

--- a/src/playground.js
+++ b/src/playground.js
@@ -14,43 +14,32 @@ var createScene = function () {
     plane1.rotateAround(BABYLON.Vector3.ZeroReadOnly, BABYLON.Vector3.RightHandedForwardReadOnly, Math.PI / 8)
     plane1.scaling.y = 0.25
     plane1.position.set(-7, 0, 0)
-    plane1.physicsImpostor =  new BABYLON.PhysicsImpostor(plane1, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, restitution: 1 }, scene)
-    // plane1.physicsImpostor.physicsBody.shapes.collidesWith = 2
-    plane1.physicsImpostor.executeNativeFunction((world, physicsBody) => {
-        console.debug(world)
-        console.debug(physicsBody)
-        world.removeCollisionObject(physicsBody)
-        world.addCollisionObject(physicsBody, 2, 1)
-    })
+    plane1.physicsImpostor =  new BABYLON.PhysicsImpostor(plane1, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, friction: 0, restitution: 1 }, scene)
 
     const plane2 = plane1.clone()
     plane2.name = "plane 2"
     plane2.rotateAround(BABYLON.Vector3.ZeroReadOnly, BABYLON.Vector3.RightHandedForwardReadOnly, -Math.PI / 3)
     plane2.scaling.x = 2
     plane2.position.set(7, 0, 0)
-    plane2.physicsImpostor =  new BABYLON.PhysicsImpostor(plane2, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, restitution: 1 }, scene)
-    // plane2.physicsImpostor.physicsBody.shapes.collidesWith = 2
+    plane2.physicsImpostor =  new BABYLON.PhysicsImpostor(plane2, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, friction: 0, restitution: 1 }, scene)
 
     const onCollide = (collider, collidedAgainst, point) => {
         if (collider.object.name != "") {
-            // console.debug(`collider = ${collider.object.name}, collidedAgainst = ${collidedAgainst.object.name}, at point = ${point}`)
+            console.debug(`collider = ${collider.object.name}, collidedAgainst = ${collidedAgainst.object.name}, at point = ${point}`)
         }
     }
 
     setInterval(() => {
         let sphere = BABYLON.MeshBuilder.CreateSphere(`sphere`, { diameter: 0.5, segments: 32 }, scene)
         sphere.position.set(-10, 12, 0)
-        sphere.physicsImpostor = new BABYLON.PhysicsImpostor(sphere, BABYLON.PhysicsImpostor.SphereImpostor, { mass: 1, restitution: 0.95,  }, scene)
-        // sphere.physicsImpostor.physicsBody.shapes.belongsTo = 2
-        // sphere.physicsImpostor.physicsBody.shapes.collidesWith = 1
+        sphere.physicsImpostor = new BABYLON.PhysicsImpostor(sphere, BABYLON.PhysicsImpostor.SphereImpostor, { mass: 1, friction: 0, restitution: 1 }, scene)
         sphere.physicsImpostor.executeNativeFunction((world, physicsBody) => {
             world.removeCollisionObject(physicsBody)
-            //world.addCollisionObject(physicsBody, 1, 1)
             world.addRigidBody(physicsBody, 1, 2)
         })
         plane1.physicsImpostor.registerOnPhysicsCollide(sphere.physicsImpostor, onCollide)
         plane2.physicsImpostor.registerOnPhysicsCollide(sphere.physicsImpostor, onCollide)
-    }, 100)
+    }, 500)
 
     return scene
 }

--- a/src/playground.js
+++ b/src/playground.js
@@ -1,8 +1,6 @@
 var createScene = function () {
     const scene = new BABYLON.Scene(engine)
     scene.enablePhysics(new BABYLON.Vector3(0, -4, 0), new BABYLON.AmmoJSPlugin(true, ammo))
-    // const physicsEngine = scene.getPhysicsEngine();
-    // physicsEngine.setSubTimeStep(10);
 
     var camera = new BABYLON.FreeCamera(`camera`, new BABYLON.Vector3(0, 5, -50), scene)
     camera.setTarget(BABYLON.Vector3.Zero())
@@ -18,6 +16,12 @@ var createScene = function () {
     plane1.position.set(-7, 0, 0)
     plane1.physicsImpostor =  new BABYLON.PhysicsImpostor(plane1, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, restitution: 1 }, scene)
     // plane1.physicsImpostor.physicsBody.shapes.collidesWith = 2
+    plane1.physicsImpostor.executeNativeFunction((world, physicsBody) => {
+        console.debug(world)
+        console.debug(physicsBody)
+        world.removeCollisionObject(physicsBody)
+        world.addCollisionObject(physicsBody, 2, 1)
+    })
 
     const plane2 = plane1.clone()
     plane2.name = "plane 2"
@@ -29,7 +33,7 @@ var createScene = function () {
 
     const onCollide = (collider, collidedAgainst, point) => {
         if (collider.object.name != "") {
-            console.debug(`collider = ${collider.object.name}, collidedAgainst = ${collidedAgainst.object.name}, at point = ${point}`)
+            // console.debug(`collider = ${collider.object.name}, collidedAgainst = ${collidedAgainst.object.name}, at point = ${point}`)
         }
     }
 
@@ -39,6 +43,11 @@ var createScene = function () {
         sphere.physicsImpostor = new BABYLON.PhysicsImpostor(sphere, BABYLON.PhysicsImpostor.SphereImpostor, { mass: 1, restitution: 0.95,  }, scene)
         // sphere.physicsImpostor.physicsBody.shapes.belongsTo = 2
         // sphere.physicsImpostor.physicsBody.shapes.collidesWith = 1
+        sphere.physicsImpostor.executeNativeFunction((world, physicsBody) => {
+            world.removeCollisionObject(physicsBody)
+            //world.addCollisionObject(physicsBody, 1, 1)
+            world.addRigidBody(physicsBody, 1, 2)
+        })
         plane1.physicsImpostor.registerOnPhysicsCollide(sphere.physicsImpostor, onCollide)
         plane2.physicsImpostor.registerOnPhysicsCollide(sphere.physicsImpostor, onCollide)
     }, 100)

--- a/src/playground.js
+++ b/src/playground.js
@@ -5,7 +5,7 @@ var createScene = function () {
     const camera = new BABYLON.ArcRotateCamera(`camera`, -Math.PI / 2, Math.PI / 2, 50, BABYLON.Vector3.ZeroReadOnly)
     camera.attachControl(null, true)
 
-    const light = new BABYLON.HemisphericLight("light", new BABYLON.Vector3(0, 1, 0), scene)
+    const light = new BABYLON.HemisphericLight(`light`, new BABYLON.Vector3(0, 1, 0), scene)
     light.intensity = 0.7
 
     const plane1 = BABYLON.MeshBuilder.CreatePlane(`plane 1`, { size: 8, sideOrientation: BABYLON.Mesh.DOUBLESIDE })
@@ -13,14 +13,13 @@ var createScene = function () {
     plane1.rotateAround(BABYLON.Vector3.ZeroReadOnly, BABYLON.Vector3.RightHandedForwardReadOnly, Math.PI / 8)
     plane1.scaling.y = 0.25
     plane1.position.set(-7, 0, 0)
-    plane1.physicsImpostor =  new BABYLON.PhysicsImpostor(plane1, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, friction: 0, restitution: 1 }, scene)
+    plane1.physicsImpostor =  new BABYLON.PhysicsImpostor(plane1, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, restitution: 1 }, scene)
 
-    const plane2 = plane1.clone()
-    plane2.name = "plane 2"
+    const plane2 = plane1.clone(`plane 2`)
     plane2.rotateAround(BABYLON.Vector3.ZeroReadOnly, BABYLON.Vector3.RightHandedForwardReadOnly, -Math.PI / 3)
     plane2.scaling.x = 2
     plane2.position.set(7, 0, 0)
-    plane2.physicsImpostor =  new BABYLON.PhysicsImpostor(plane2, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, friction: 0, restitution: 1 }, scene)
+    plane2.physicsImpostor =  new BABYLON.PhysicsImpostor(plane2, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, restitution: 1 }, scene)
 
     const onCollide = (collider, collidedAgainst, point) => {
         if (collider.object.name != "") {
@@ -31,7 +30,7 @@ var createScene = function () {
     setInterval(() => {
         let sphere = BABYLON.MeshBuilder.CreateSphere(`sphere`, { diameter: 0.5, segments: 32 }, scene)
         sphere.position.set(-10, 12, 0)
-        sphere.physicsImpostor = new BABYLON.PhysicsImpostor(sphere, BABYLON.PhysicsImpostor.SphereImpostor, { mass: 1, friction: 0, restitution: 1 }, scene)
+        sphere.physicsImpostor = new BABYLON.PhysicsImpostor(sphere, BABYLON.PhysicsImpostor.SphereImpostor, { mass: 1, restitution: 1 }, scene)
         sphere.physicsImpostor.executeNativeFunction((world, physicsBody) => {
             world.removeCollisionObject(physicsBody)
             world.addRigidBody(physicsBody, 1, 2)

--- a/src/playground.js
+++ b/src/playground.js
@@ -25,7 +25,8 @@ var createScene = function () {
         const sphere = collider.object
         const now = Date.now()
         if (200 < now - sphere.lastCollisionTime) {
-            console.debug(`plane frequency factor = ${1 / collidedAgainst.object.scaling.x}`)
+            // console.debug(`plane frequency factor = ${1 / collidedAgainst.object.scaling.x}`)
+            const frequencyFactor = collidedAgainst.object.scaling.x
             sphere.lastCollisionTime = now
         }
     }

--- a/src/playground.js
+++ b/src/playground.js
@@ -22,8 +22,11 @@ var createScene = function () {
     plane2.physicsImpostor =  new BABYLON.PhysicsImpostor(plane2, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, restitution: 1 }, scene)
 
     const onCollide = (collider, collidedAgainst, point) => {
-        if (collider.object.name != "") {
-            console.debug(`collider = ${collider.object.name}, collidedAgainst = ${collidedAgainst.object.name}, at point = ${point}`)
+        const sphere = collider.object
+        const now = Date.now()
+        if (200 < now - sphere.lastCollisionTime) {
+            console.debug(`plane frequency factor = ${1 / collidedAgainst.object.scaling.x}`)
+            sphere.lastCollisionTime = now
         }
     }
 
@@ -35,8 +38,9 @@ var createScene = function () {
             world.removeCollisionObject(physicsBody)
             world.addRigidBody(physicsBody, 1, 2)
         })
-        plane1.physicsImpostor.registerOnPhysicsCollide(sphere.physicsImpostor, onCollide)
-        plane2.physicsImpostor.registerOnPhysicsCollide(sphere.physicsImpostor, onCollide)
+        sphere.physicsImpostor.registerOnPhysicsCollide(plane1.physicsImpostor, onCollide)
+        sphere.physicsImpostor.registerOnPhysicsCollide(plane2.physicsImpostor, onCollide)
+        sphere.lastCollisionTime = 0
     }, 500)
 
     return scene

--- a/src/playground.js
+++ b/src/playground.js
@@ -2,8 +2,7 @@ var createScene = function () {
     const scene = new BABYLON.Scene(engine)
     scene.enablePhysics(new BABYLON.Vector3(0, -4, 0), new BABYLON.AmmoJSPlugin(false, ammo))
 
-    var camera = new BABYLON.FreeCamera(`camera`, new BABYLON.Vector3(0, 5, -50), scene)
-    camera.setTarget(BABYLON.Vector3.Zero())
+    const camera = new BABYLON.ArcRotateCamera(`camera`, -Math.PI / 2, Math.PI / 2, 50, BABYLON.Vector3.ZeroReadOnly)
     camera.attachControl(null, true)
 
     const light = new BABYLON.HemisphericLight("light", new BABYLON.Vector3(0, 1, 0), scene)

--- a/src/playground.js
+++ b/src/playground.js
@@ -1,10 +1,10 @@
 var createScene = function () {
     const scene = new BABYLON.Scene(engine)
-    scene.enablePhysics(new BABYLON.Vector3(0, -4, 0), new BABYLON.AmmoJSPlugin(true, 1, ammo))
-    const physicsEngine = scene.getPhysicsEngine();
-    physicsEngine.setSubTimeStep(10);
+    scene.enablePhysics(new BABYLON.Vector3(0, -4, 0), new BABYLON.AmmoJSPlugin(true, ammo))
+    // const physicsEngine = scene.getPhysicsEngine();
+    // physicsEngine.setSubTimeStep(10);
 
-    var camera = new BABYLON.FreeCamera(`camera`, new BABYLON.Vector3(0, 5, -20), scene)
+    var camera = new BABYLON.FreeCamera(`camera`, new BABYLON.Vector3(0, 5, -50), scene)
     camera.setTarget(BABYLON.Vector3.Zero())
     camera.attachControl(null, true)
 
@@ -17,7 +17,7 @@ var createScene = function () {
     plane1.scaling.y = 0.25
     plane1.position.set(-7, 0, 0)
     plane1.physicsImpostor =  new BABYLON.PhysicsImpostor(plane1, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, restitution: 1 }, scene)
-    plane1.physicsImpostor.physicsBody.shapes.collidesWith = 2
+    // plane1.physicsImpostor.physicsBody.shapes.collidesWith = 2
 
     const plane2 = plane1.clone()
     plane2.name = "plane 2"
@@ -25,7 +25,7 @@ var createScene = function () {
     plane2.scaling.x = 2
     plane2.position.set(7, 0, 0)
     plane2.physicsImpostor =  new BABYLON.PhysicsImpostor(plane2, BABYLON.PhysicsImpostor.BoxImpostor, { mass: 0, restitution: 1 }, scene)
-    plane2.physicsImpostor.physicsBody.shapes.collidesWith = 2
+    // plane2.physicsImpostor.physicsBody.shapes.collidesWith = 2
 
     const onCollide = (collider, collidedAgainst, point) => {
         if (collider.object.name != "") {
@@ -33,12 +33,12 @@ var createScene = function () {
         }
     }
 
-    setTimeout(() => {
+    setInterval(() => {
         let sphere = BABYLON.MeshBuilder.CreateSphere(`sphere`, { diameter: 0.5, segments: 32 }, scene)
         sphere.position.set(-10, 12, 0)
         sphere.physicsImpostor = new BABYLON.PhysicsImpostor(sphere, BABYLON.PhysicsImpostor.SphereImpostor, { mass: 1, restitution: 0.95,  }, scene)
-        sphere.physicsImpostor.physicsBody.shapes.belongsTo = 2
-        sphere.physicsImpostor.physicsBody.shapes.collidesWith = 1
+        // sphere.physicsImpostor.physicsBody.shapes.belongsTo = 2
+        // sphere.physicsImpostor.physicsBody.shapes.collidesWith = 1
         plane1.physicsImpostor.registerOnPhysicsCollide(sphere.physicsImpostor, onCollide)
         plane2.physicsImpostor.registerOnPhysicsCollide(sphere.physicsImpostor, onCollide)
     }, 100)

--- a/src/playground.js
+++ b/src/playground.js
@@ -1,6 +1,6 @@
 var createScene = function () {
     const scene = new BABYLON.Scene(engine)
-    scene.enablePhysics(new BABYLON.Vector3(0, -4, 0), new BABYLON.AmmoJSPlugin(true, ammo))
+    scene.enablePhysics(new BABYLON.Vector3(0, -4, 0), new BABYLON.AmmoJSPlugin(false, ammo))
 
     var camera = new BABYLON.FreeCamera(`camera`, new BABYLON.Vector3(0, 5, -50), scene)
     camera.setTarget(BABYLON.Vector3.Zero())

--- a/src/playground.js
+++ b/src/playground.js
@@ -1,6 +1,6 @@
 var createScene = function () {
     const scene = new BABYLON.Scene(engine)
-    scene.enablePhysics(new BABYLON.Vector3(0, -4, 0), new BABYLON.OimoJSPlugin(true, 1, OIMO))
+    scene.enablePhysics(new BABYLON.Vector3(0, -4, 0), new BABYLON.AmmoJSPlugin(true, 1, ammo))
     const physicsEngine = scene.getPhysicsEngine();
     physicsEngine.setSubTimeStep(10);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,11 +2,11 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path')
 
 const externals = [
-    {
-        name: 'ammo.js',
-        globalVarName: 'Ammo',
-        src: 'https://cdn.babylonjs.com/ammo.js',
-    },
+    // {
+    //     name: 'ammo.js',
+    //     globalVarName: 'Ammo',
+    //     src: 'https://raw.githubusercontent.com/kripken/ammo.js/main/builds/ammo.js',
+    // },
     {
         name: 'babylonjs',
         globalVarName: 'BABYLON',
@@ -42,5 +42,11 @@ module.exports = {
             template: path.resolve(__dirname, 'src', 'index.html'),
             title: 'soundrop3d',
         }),
-    ]
+    ],
+    resolve: {
+        fallback: {
+            'fs': false,
+            'path': false, // ammo.js seems to also use path
+        }
+    }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,14 +3,14 @@ const path = require('path')
 
 const externals = [
     {
+        name: 'ammo.js',
+        globalVarName: 'Ammo',
+        src: 'https://cdn.babylonjs.com/ammo.js',
+    },
+    {
         name: 'babylonjs',
         globalVarName: 'BABYLON',
         src: 'https://cdn.babylonjs.com/babylon.js',
-    },
-    {
-        name: 'oimo',
-        globalVarName: 'OIMO',
-        src: 'https://cdn.babylonjs.com/Oimo.js',
     },
 ]
 


### PR DESCRIPTION
Webpack compiles without error after this change but a runtime error occurs:
```
ammoJSPlugin.ts:89 Uncaught TypeError: this.bjsAMMO.btSoftBodyRigidBodyCollisionConfiguration is not a constructor
    at new e (ammoJSPlugin.ts:89:40)
    at createScene (playground.js:3:1)
    at app.js:12:1
    at app.js:3233:3
    at app.js:3235:12
e @ ammoJSPlugin.ts:89
createScene @ playground.js:3
(anonymous) @ app.js:12
(anonymous) @ app.js:3233
(anonymous) @ app.js:3235
```